### PR TITLE
Update base images and dependencies to version 5.9.8

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,23 +1,23 @@
-# Using debian 11 as base image.
-FROM debian:11
+# Using debian latest as base image.
+FROM debian:latest
 
 # Label base
 LABEL maintainer="Alex Kislitsa"
 
 # Radare version
 ARG R2_VERSION=master
-ARG R2_TAG=5.6.8
+ARG R2_TAG=5.9.8
 # R2pipe python version
 ARG R2_PIPE_PY_VERSION=1.6.5
 
-ENV R2_VERSION ${R2_VERSION}
-ENV R2_TAG ${R2_TAG}
+ENV R2_VERSION=${R2_VERSION}
+ENV R2_TAG=${R2_TAG}
 
 RUN echo -e "Building versions:\n\R2_VERSION=${R2_VERSION}\n\R2_TAG=${R2_TAG}"
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
-ENV TZ UTC
+ENV TZ=UTC
 
 # Install all build dependencies
 # Install bindings
@@ -42,6 +42,7 @@ RUN dpkg --add-architecture i386 && \
   libssl-dev \
   python3-dev \
   python3-pip \
+  pipx \
   build-essential \
   ruby \
   ruby-dev \
@@ -52,7 +53,7 @@ RUN dpkg --add-architecture i386 && \
   wget \
   gdb \
   gdb-multiarch \
-  netcat \
+  netcat-traditional \
   socat \
   git \
   patchelf \
@@ -63,8 +64,8 @@ RUN dpkg --add-architecture i386 && \
   rpm2cpio cpio \
   zstd \
   tzdata --fix-missing \
-  sudo \
-  python-is-python3 && \
+  sudo && \
+  # python-is-python3 && \
   rm -rf /var/lib/apt/list/*
 
 # Create non-root user
@@ -76,27 +77,27 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 # Initilise base user
 USER r2
 WORKDIR /home/r2
-ENV HOME /home/r2
+ENV HOME=/home/r2
 
 # Setup r2env, r2pm and pwn tools
 RUN \
   echo "export GIT_PYTHON_REFRESH=quiet" >> ${HOME}/.bashrc && \
   git config --global pull.rebase false && \
-  pip install --upgrade r2env --no-warn-script-location && \
+  pipx install r2env && \
   ${HOME}/.local/bin/r2env init && \
   ${HOME}/.local/bin/r2env add radare2@${R2_TAG} && \
   ${HOME}/.local/bin/r2env use radare2@${R2_TAG} && \
-  python3 -m pip install -U pip && \
-  python3 -m pip install --no-cache-dir \
-  ropgadget \
-  z3-solver \
+  pipx install ROPgadget &&  \
+  pipx install z3-solver &&  \
+  pipx install ropper &&  \
+  pipx install angr &&  \
+  pipx install frida-tools && \
+  pip install --no-cache-dir --break-system-packages \
   smmap2 \
   apscheduler \
-  ropper \
   unicorn \
   keystone-engine \
   capstone \
-  angr \
   pebble \
   r2pipe \
   pwntools --no-warn-script-location && \
@@ -111,4 +112,4 @@ COPY .tmux.conf ${HOME}/.tmux.conf
 
 RUN cd pwndbg && ./setup.sh && \
   gem install --user one_gadget && \
-  echo "PATH=${HOME}/.local/bin:${HOME}/.r2env/bin:$(find ~ -name one_gadget -exec dirname {} \; | tail -n 1):$PATH" >> $HOME/.bashrc
+  echo "PATH=${HOME}/.local/bin:${HOME}/.r2env/bin:$(find ~ -type f -name one_gadget -exec dirname {} \; | tail -n 1):$PATH" >> $HOME/.bashrc

--- a/Dockerfile.ctf
+++ b/Dockerfile.ctf
@@ -1,4 +1,4 @@
-FROM luckycatalex/radare2-r2ghidra:5.6.8
+FROM luckycatalex/radare2-r2ghidra:5.9.8
 
 # Label base
 LABEL maintainer="Alex Kislitsa"

--- a/Dockerfile.r2ghidra
+++ b/Dockerfile.r2ghidra
@@ -1,4 +1,4 @@
-FROM luckycatalex/radare2-base:5.6.8
+FROM luckycatalex/radare2-base:5.9.8
 
 # Label base
 LABEL maintainer="Alex Kislitsa"
@@ -10,4 +10,4 @@ LABEL maintainer="Alex Kislitsa"
 
 # Setup r2pm
 RUN \
-  export PATH=~/.local/bin:~/.r2env/bin:$PATH && r2pm init && r2pm update && r2pm -ci r2ghidra
+  export PATH=~/.local/bin:~/.r2env/bin:$PATH && r2pm -U && r2pm -i r2ghidra r2ghidra-sleigh 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 5.6.8
+VERSION ?= 5.9.8
 IMAGE_NAME ?= luckycatalex/radare2
 
 # This will output the help for each task

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Old image kind of "all-in-one" type
 
 ### Usage
 ```
-docker run --network=host --rm -v $(pwd):/work_dir -it luckycatalex/radare2-multilib:5.6.8  bash
+docker run --network=host --rm -v $(pwd):/work_dir -it luckycatalex/radare2-multilib:5.9.8  bash
 ```
 
 ## radare2-base
@@ -15,7 +15,7 @@ The base image that will be used from other images, you can use him
 
 ### Usage
 ```
-docker run --network=host --rm -v $(pwd):/work_dir -it luckycatalex/radare2-base:5.6.8  bash
+docker run --network=host --rm -v $(pwd):/work_dir -it luckycatalex/radare2-base:5.9.8  bash
 ```
 
 ### included software
@@ -39,7 +39,7 @@ Based on radare2-base and have installed r2ghidra plugin by default
 
 ### Usage
 ```
-docker run --network=host --rm -v $(pwd):/work_dir -it luckycatalex/radare2-r2ghidra:5.6.8  bash
+docker run --network=host --rm -v $(pwd):/work_dir -it luckycatalex/radare2-r2ghidra:5.9.8  bash
 ```
 
 ## radare2-ctf
@@ -48,7 +48,7 @@ Based on radare2-r2ghidra
 
 ### Usage
 ```
-docker run --network=host --rm -v $(pwd):/work_dir -it luckycatalex/radare2-ctf:5.6.8  bash
+docker run --network=host --rm -v $(pwd):/work_dir -it luckycatalex/radare2-ctf:5.9.8  bash
 ```
 
 ### included glibc


### PR DESCRIPTION
Upgrade the base images and dependencies to version 5.9.8, ensuring compatibility with the latest features and improvements. Adjust installation commands and environment variables accordingly.